### PR TITLE
Pass CI

### DIFF
--- a/znap-cli/src/commands/build.rs
+++ b/znap-cli/src/commands/build.rs
@@ -1,6 +1,6 @@
 use crate::utils::{build_for_release, generate_collection_executable_files, get_config};
 
-pub fn run(name: &String) {
+pub fn run(name: &str) {
     let config = get_config();
     let collections = config.collections.unwrap_or_default();
     let collection = collections

--- a/znap-cli/src/commands/build.rs
+++ b/znap-cli/src/commands/build.rs
@@ -2,7 +2,7 @@ use crate::utils::{build_for_release, generate_collection_executable_files, get_
 
 pub fn run(name: &String) {
     let config = get_config();
-    let collections = config.collections.unwrap_or(vec![]);
+    let collections = config.collections.unwrap_or_default();
     let collection = collections
         .iter()
         .find(|collection| collection.name == *name);

--- a/znap-cli/src/commands/clean.rs
+++ b/znap-cli/src/commands/clean.rs
@@ -10,5 +10,5 @@ pub fn run() {
 
     // Create a new .znap folder with a .gitkeep
     create_dir(&znap_path).expect("Should be able to create a .znap folder");
-    File::create(&znap_gitkeep_path).expect("Should be able to create a .znap/.gitkeep file");
+    File::create(znap_gitkeep_path).expect("Should be able to create a .znap/.gitkeep file");
 }

--- a/znap-cli/src/commands/deploy.rs
+++ b/znap-cli/src/commands/deploy.rs
@@ -1,6 +1,6 @@
 use crate::utils::{deploy_to_shuttle, generate_collection_executable_files, get_config};
 
-pub fn run(name: &String, project: &String) {
+pub fn run(name: &str, project: &str) {
     let config = get_config();
     let collections = config.collections.unwrap_or_default();
     let collection = collections

--- a/znap-cli/src/commands/deploy.rs
+++ b/znap-cli/src/commands/deploy.rs
@@ -2,7 +2,7 @@ use crate::utils::{deploy_to_shuttle, generate_collection_executable_files, get_
 
 pub fn run(name: &String, project: &String) {
     let config = get_config();
-    let collections = config.collections.unwrap_or(vec![]);
+    let collections = config.collections.unwrap_or_default();
     let collection = collections
         .iter()
         .find(|collection| collection.name == *name);

--- a/znap-cli/src/commands/init.rs
+++ b/znap-cli/src/commands/init.rs
@@ -20,7 +20,7 @@ pub fn run(name: &String, dry_run: &bool) {
 
 "#;
     println!("{}", message.bold().yellow());
-    println!("");
+    println!();
     println!("Someone is about to get some action...");
     println!(
         "No worries, we got you. {}{}{}",
@@ -28,7 +28,7 @@ pub fn run(name: &String, dry_run: &bool) {
         "BLINK BLINK".bold().italic(),
         Emoji("✨", "")
     );
-    println!("");
+    println!();
     println!(
         "You are about to create a {} named: {}\n",
         "Znap workspace".bold(),
@@ -57,7 +57,7 @@ pub fn run(name: &String, dry_run: &bool) {
 
         write_file(
             workspace_dir.join("Znap.toml").as_path(),
-            &format!("identity = \"~/.config/solana/id.json\""),
+            &"identity = \"~/.config/solana/id.json\"".to_string(),
         );
 
         // Create a default actions.json file
@@ -121,7 +121,7 @@ pub fn run(name: &String, dry_run: &bool) {
         );
 
         // Create a collections folder.
-        create_dir(&collections_dir).unwrap();
+        create_dir(collections_dir).unwrap();
 
         // Create a .gitkeep in the collections folder.
         write_file(
@@ -130,7 +130,7 @@ pub fn run(name: &String, dry_run: &bool) {
         );
 
         // Create a tests folder.
-        create_dir(&tests_dir).unwrap();
+        create_dir(tests_dir).unwrap();
 
         // Create a tests/utils.ts file.
         write_file(
@@ -216,7 +216,7 @@ describe("My tests", () => {
         );
 
         // Create a .znap folder.
-        create_dir(&znap_dir).unwrap();
+        create_dir(znap_dir).unwrap();
 
         // Create a .gitkeep in the .znap folder.
         write_file(znap_dir.join(".gitkeep").as_path(), &String::from(""));

--- a/znap-cli/src/commands/init.rs
+++ b/znap-cli/src/commands/init.rs
@@ -4,7 +4,7 @@ use console::Emoji;
 use heck::ToKebabCase;
 use std::fs::create_dir;
 
-pub fn run(name: &String, dry_run: &bool) {
+pub fn run(name: &str, dry_run: bool) {
     std::process::Command::new("clear").status().unwrap();
     println!("\n");
     let message = r#"
@@ -32,7 +32,7 @@ pub fn run(name: &String, dry_run: &bool) {
     println!(
         "You are about to create a {} named: {}\n",
         "Znap workspace".bold(),
-        &name.cyan()
+        name.cyan()
     );
 
     let cwd = std::env::current_dir().unwrap();
@@ -47,36 +47,33 @@ pub fn run(name: &String, dry_run: &bool) {
 
         // Create a Cargo.toml file.
         write_file(
-            workspace_dir.join("Cargo.toml").as_path(),
-            &String::from(
+            &workspace_dir.join("Cargo.toml"),
                 "[workspace]\nmembers = [\"collections/*\"]\nresolver = \"2\"\n\n[patch.crates-io]\ncurve25519-dalek = { git = \"https://github.com/dalek-cryptography/curve25519-dalek\", rev = \"8274d5cbb6fc3f38cdc742b4798173895cd2a290\" }",
-            ),
         );
 
         // Create a Znap.toml file.
 
         write_file(
-            workspace_dir.join("Znap.toml").as_path(),
-            &"identity = \"~/.config/solana/id.json\"".to_string(),
+            &workspace_dir.join("Znap.toml"),
+            "identity = \"~/.config/solana/id.json\"",
         );
 
         // Create a default actions.json file
         write_file(
-            workspace_dir.join("actions.json").as_path(),
-            &String::from("{\"rules\":[{\"pathPattern\":\"/**\",\"apiPath\":\"/api/**\"}]}"),
+            &workspace_dir.join("actions.json"),
+            "{\"rules\":[{\"pathPattern\":\"/**\",\"apiPath\":\"/api/**\"}]}",
         );
 
         // Create a .gitignore file.
         write_file(
-            workspace_dir.join(".gitignore").as_path(),
-            &String::from("/target\n.znap\nnode_modules"),
+            &workspace_dir.join(".gitignore"),
+            "/target\n.znap\nnode_modules",
         );
 
         // Create a package.json file.
         write_file(
-            workspace_dir.join("package.json").as_path(),
-            &String::from(
-                r#"
+            &workspace_dir.join("package.json"),
+            r#"
 {
     "scripts": {
         "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
@@ -98,14 +95,12 @@ pub fn run(name: &String, dry_run: &bool) {
     }
 }
 "#,
-            ),
         );
 
         // Create a tsconfig.json file.
         write_file(
-            workspace_dir.join("tsconfig.json").as_path(),
-            &String::from(
-                r#"
+            &workspace_dir.join("tsconfig.json"),
+            r#"
 {
   "compilerOptions": {
     "types": ["mocha", "chai", "node"],
@@ -117,26 +112,21 @@ pub fn run(name: &String, dry_run: &bool) {
   }
 }
 "#,
-            ),
         );
 
         // Create a collections folder.
         create_dir(collections_dir).unwrap();
 
         // Create a .gitkeep in the collections folder.
-        write_file(
-            collections_dir.join(".gitkeep").as_path(),
-            &String::from(""),
-        );
+        write_file(&collections_dir.join(".gitkeep"), "");
 
         // Create a tests folder.
         create_dir(tests_dir).unwrap();
 
         // Create a tests/utils.ts file.
         write_file(
-            tests_dir.join("utils.ts").as_path(),
-            &String::from(
-                r#"
+            &tests_dir.join("utils.ts"),
+            r#"
 export interface Action {
   label: string;
   href: string;
@@ -194,14 +184,12 @@ export function createActionClient(actionUrl: string) {
   };
 }
 "#,
-            ),
         );
 
         // Create a tests/e2e.ts file.
         write_file(
-            tests_dir.join("e2e.ts").as_path(),
-            &String::from(
-                r#"
+            &tests_dir.join("e2e.ts"),
+            r#"
 import { assert } from "chai";
 
 describe("My tests", () => {
@@ -212,30 +200,26 @@ describe("My tests", () => {
   });
 });
 "#,
-            ),
         );
 
         // Create a .znap folder.
         create_dir(znap_dir).unwrap();
 
         // Create a .gitkeep in the .znap folder.
-        write_file(znap_dir.join(".gitkeep").as_path(), &String::from(""));
+        write_file(&znap_dir.join(".gitkeep"), "");
     }
 
     println!("  Added:\n");
-    println!("      {}", format!("+ {}/Cargo.toml", &name).green());
-    println!("      {}", format!("+ {}/Znap.toml", &name).green());
-    println!("      {}", format!("+ {}/package.json", &name).green());
-    println!("      {}", format!("+ {}/tsconfig.json", &name).green());
-    println!("      {}", format!("+ {}/actions.json", &name).green());
-    println!("      {}", format!("+ {}/.gitignore", &name).green());
-    println!("      {}", format!("+ {}/.znap/.gitkeep", &name).green());
-    println!(
-        "      {}",
-        format!("+ {}/collections/.gitkeep", &name).green()
-    );
-    println!("      {}", format!("+ {}/tests/utils.ts", &name).green());
-    println!("      {}", format!("+ {}/tests/e2e.ts", &name).green());
+    println!("      {}", format!("+ {name}/Cargo.toml").green());
+    println!("      {}", format!("+ {name}/Znap.toml").green());
+    println!("      {}", format!("+ {name}/package.json").green());
+    println!("      {}", format!("+ {name}/tsconfig.json").green());
+    println!("      {}", format!("+ {name}/actions.json").green());
+    println!("      {}", format!("+ {name}/.gitignore").green());
+    println!("      {}", format!("+ {name}/.znap/.gitkeep").green());
+    println!("      {}", format!("+ {name}/collections/.gitkeep").green());
+    println!("      {}", format!("+ {name}/tests/utils.ts").green());
+    println!("      {}", format!("+ {name}/tests/e2e.ts").green());
 
     println!(
         "\nZnap workspace created at {}\n",

--- a/znap-cli/src/commands/new.rs
+++ b/znap-cli/src/commands/new.rs
@@ -6,10 +6,10 @@ use colored::Colorize;
 use heck::ToKebabCase;
 use std::fs::{create_dir, read_to_string};
 
-pub fn run(name: &String, dry_run: &bool) {
+pub fn run(name: &str, dry_run: bool) {
     println!(
         "\nYou are about to create a collection named: {}\n",
-        &name.cyan()
+        name.cyan()
     );
 
     // Create a folder for the collection in the collections folder.
@@ -78,11 +78,11 @@ pub fn run(name: &String, dry_run: &bool) {
     println!("  Added:\n");
     println!(
         "      {}",
-        format!("+ collections/{}/Cargo.toml", &name).green()
+        format!("+ collections/{name}/Cargo.toml").green()
     );
     println!(
         "      {}",
-        format!("+ collections/{}/src/lib.rs", &name).green()
+        format!("+ collections/{name}/src/lib.rs").green()
     );
     println!();
     println!("  Modified:\n");
@@ -90,7 +90,7 @@ pub fn run(name: &String, dry_run: &bool) {
 
     println!(
         "\nCollection created at {}\n",
-        format!("file://{}", &collection_dir.to_str().unwrap())
+        format!("file://{}", collection_dir.to_str().unwrap())
             .italic()
             .bold()
     );

--- a/znap-cli/src/commands/new.rs
+++ b/znap-cli/src/commands/new.rs
@@ -52,7 +52,7 @@ pub fn run(name: &String, dry_run: &bool) {
         // Create a Cargo.toml for the collection.
         write_file(
             collection_dir.join("Cargo.toml").as_path(),
-            &template::new_collection_toml::template(&name),
+            &template::new_collection_toml::template(name),
         );
 
         // Create a src folder.
@@ -61,12 +61,12 @@ pub fn run(name: &String, dry_run: &bool) {
         // Create a lib.rs in the src folder.
         write_file(
             collection_src_dir.join("lib.rs").as_path(),
-            &template::new_collection_body::template(&name),
+            &template::new_collection_body::template(name),
         );
 
         // Add to collections list in Znap.toml.
         write_file(
-            &znap_toml_path.as_path(),
+            znap_toml_path.as_path(),
             &toml::to_string(&Config {
                 collections,
                 identity: "~/.config/solana/id.json".to_string(),
@@ -84,7 +84,7 @@ pub fn run(name: &String, dry_run: &bool) {
         "      {}",
         format!("+ collections/{}/src/lib.rs", &name).green()
     );
-    println!("");
+    println!();
     println!("  Modified:\n");
     println!("      {}", "* ./Znap.toml".green());
 

--- a/znap-cli/src/commands/serve.rs
+++ b/znap-cli/src/commands/serve.rs
@@ -4,7 +4,7 @@ use crate::utils::{
 
 pub fn run(name: &String, address: &Option<String>, port: &Option<u16>, protocol: &Option<String>) {
     let config = get_config();
-    let collections = config.collections.unwrap_or(vec![]);
+    let collections = config.collections.unwrap_or_default();
     let collection = collections
         .iter()
         .find(|collection| collection.name == *name);

--- a/znap-cli/src/commands/serve.rs
+++ b/znap-cli/src/commands/serve.rs
@@ -2,7 +2,7 @@ use crate::utils::{
     generate_collection_executable_files, get_config, get_identity, start_server_blocking,
 };
 
-pub fn run(name: &String, address: &Option<String>, port: &Option<u16>, protocol: &Option<String>) {
+pub fn run(name: &str, address: Option<&str>, port: Option<&u16>, protocol: Option<&str>) {
     let config = get_config();
     let collections = config.collections.unwrap_or_default();
     let collection = collections

--- a/znap-cli/src/commands/test.rs
+++ b/znap-cli/src/commands/test.rs
@@ -20,9 +20,9 @@ pub fn run() {
         let server_process = start_server(
             &collection.name,
             &get_identity(&config.identity),
-            &Some(collection.address.clone()),
-            &Some(collection.port),
-            &Some(collection.protocol.clone()),
+            Some(&collection.address),
+            Some(&collection.port),
+            Some(&collection.protocol),
         );
 
         // While true with a sleep until server is online

--- a/znap-cli/src/commands/test.rs
+++ b/znap-cli/src/commands/test.rs
@@ -7,7 +7,7 @@ use std::process::Child;
 pub fn run() {
     // get config
     let config = get_config();
-    let collections = config.collections.unwrap_or(vec![]);
+    let collections = config.collections.unwrap_or_default();
 
     // start and wait for each server to be running
     let mut server_processes: Vec<Child> = vec![];
@@ -21,7 +21,7 @@ pub fn run() {
             &collection.name,
             &get_identity(&config.identity),
             &Some(collection.address.clone()),
-            &Some(collection.port.clone()),
+            &Some(collection.port),
             &Some(collection.protocol.clone()),
         );
 

--- a/znap-cli/src/lib.rs
+++ b/znap-cli/src/lib.rs
@@ -84,11 +84,11 @@ fn process_command(opts: Opts) -> Result<()> {
             Ok(())
         }
         Command::Init { name, dry_run } => {
-            commands::init::run(name, dry_run);
+            commands::init::run(name, *dry_run);
             Ok(())
         }
         Command::New { name, dry_run } => {
-            commands::new::run(name, dry_run);
+            commands::new::run(name, *dry_run);
             Ok(())
         }
         Command::Deploy { name, project } => {

--- a/znap-cli/src/lib.rs
+++ b/znap-cli/src/lib.rs
@@ -62,18 +62,39 @@ pub enum Command {
 
 fn process_command(opts: Opts) -> Result<()> {
     match &opts.command {
-        Command::Build { name } => Ok(commands::build::run(name)),
+        Command::Build { name } => {
+            commands::build::run(name);
+            Ok(())
+        },
         Command::Serve {
             name,
             address,
             port,
             protocol,
-        } => Ok(commands::serve::run(name, address, port, protocol)),
-        Command::Test => Ok(commands::test::run()),
-        Command::Clean => Ok(commands::clean::run()),
-        Command::Init { name, dry_run } => Ok(commands::init::run(name, dry_run)),
-        Command::New { name, dry_run } => Ok(commands::new::run(name, dry_run)),
-        Command::Deploy { name, project } => Ok(commands::deploy::run(name, project)),
+        } => {
+            commands::serve::run(name, address, port, protocol);
+            Ok(())
+        },
+        Command::Test => {
+            commands::test::run();
+            Ok(())
+        },
+        Command::Clean => {
+            commands::clean::run();
+            Ok(())
+        },
+        Command::Init { name, dry_run } => {
+            commands::init::run(name, dry_run);
+            Ok(())
+        },
+        Command::New { name, dry_run } => {
+            commands::new::run(name, dry_run);
+            Ok(())
+        },
+        Command::Deploy { name, project } => {
+            commands::deploy::run(name, project);
+            Ok(())
+        },
     }
 }
 

--- a/znap-cli/src/lib.rs
+++ b/znap-cli/src/lib.rs
@@ -65,36 +65,36 @@ fn process_command(opts: Opts) -> Result<()> {
         Command::Build { name } => {
             commands::build::run(name);
             Ok(())
-        },
+        }
         Command::Serve {
             name,
             address,
             port,
             protocol,
         } => {
-            commands::serve::run(name, address, port, protocol);
+            commands::serve::run(name, address.as_deref(), port.as_ref(), protocol.as_deref());
             Ok(())
-        },
+        }
         Command::Test => {
             commands::test::run();
             Ok(())
-        },
+        }
         Command::Clean => {
             commands::clean::run();
             Ok(())
-        },
+        }
         Command::Init { name, dry_run } => {
             commands::init::run(name, dry_run);
             Ok(())
-        },
+        }
         Command::New { name, dry_run } => {
             commands::new::run(name, dry_run);
             Ok(())
-        },
+        }
         Command::Deploy { name, project } => {
             commands::deploy::run(name, project);
             Ok(())
-        },
+        }
     }
 }
 

--- a/znap-cli/src/template/collection_deploy_binary.rs
+++ b/znap-cli/src/template/collection_deploy_binary.rs
@@ -1,6 +1,6 @@
 use heck::ToSnekCase;
 
-pub fn template(name: &String) -> String {
+pub fn template(name: &str) -> String {
     format!(
         r#"
 #[shuttle_runtime::main]

--- a/znap-cli/src/template/collection_toml.rs
+++ b/znap-cli/src/template/collection_toml.rs
@@ -1,6 +1,6 @@
 use heck::ToKebabCase;
 
-pub fn template(name: &String) -> String {
+pub fn template(name: &str) -> String {
     format!(
         r#"
     

--- a/znap-cli/src/template/new_collection_body.rs
+++ b/znap-cli/src/template/new_collection_body.rs
@@ -1,6 +1,6 @@
 use heck::ToSnekCase;
 
-pub fn template(name: &String) -> String {
+pub fn template(name: &str) -> String {
     format!(
         r#"use znap::prelude::*;
 

--- a/znap-cli/src/template/new_collection_toml.rs
+++ b/znap-cli/src/template/new_collection_toml.rs
@@ -1,6 +1,6 @@
 use heck::ToKebabCase;
 
-pub fn template(name: &String) -> String {
+pub fn template(name: &str) -> String {
     format!(
         "[package]\n\
         name = \"{}\"\n\

--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -59,9 +59,9 @@ pub fn write_file(path: &Path, content: &String) {
 pub fn start_server_blocking(
     name: &str,
     identity: &str,
-    address: &Option<String>,
-    port: &Option<u16>,
-    protocol: &Option<String>,
+    address: Option<&str>,
+    port: Option<&u16>,
+    protocol: Option<&str>,
 ) {
     let start_server_process = start_server(name, identity, address, port, protocol);
     let exit = start_server_process
@@ -74,26 +74,26 @@ pub fn start_server_blocking(
 }
 
 pub fn start_server(
-    name: &String,
-    identity: &String,
-    address: &Option<String>,
-    port: &Option<u16>,
-    protocol: &Option<String>,
+    name: &str,
+    identity: &str,
+    address: Option<&str>,
+    port: Option<&u16>,
+    protocol: Option<&str>,
 ) -> Child {
-    let mut env_vars: HashMap<String, String> = HashMap::new();
+    let mut env_vars: HashMap<&str, String> = HashMap::new();
 
-    env_vars.insert("IDENTITY_KEYPAIR_PATH".to_string(), identity.clone());
+    env_vars.insert("IDENTITY_KEYPAIR_PATH", identity.to_owned());
 
     if let Some(address) = address {
-        env_vars.insert("COLLECTION_ADDRESS".to_string(), address.clone());
+        env_vars.insert("COLLECTION_ADDRESS", address.to_owned());
     }
 
-    if let Some(port) = port {
-        env_vars.insert("COLLECTION_PORT".to_string(), port.to_string());
+    if let Some(port) = port.map(|p| p.to_string()) {
+        env_vars.insert("COLLECTION_PORT", port);
     }
 
     if let Some(protocol) = protocol {
-        env_vars.insert("COLLECTION_PROTOCOL".to_string(), protocol.clone());
+        env_vars.insert("COLLECTION_PROTOCOL", protocol.to_owned());
     }
 
     std::process::Command::new("cargo")
@@ -123,7 +123,7 @@ pub fn run_test_suite() {
         .expect("Should wait until the tests are over");
 }
 
-pub fn wait_for_server(address: &String, port: &u16, protocol: &String) {
+pub fn wait_for_server(address: &str, port: &u16, protocol: &str) {
     let url = format!("{protocol}://{address}:{port}/status");
 
     loop {
@@ -197,22 +197,22 @@ pub fn generate_collection_executable_files(collection: &Collection) {
     let znap_collection_path = znap_collections_path.join(&collection.name);
 
     if znap_collection_path.exists() {
-        remove_dir_all(&znap_collection_path).unwrap_or_else(|_| panic!("Could not delete .znap/{} folder",
-            &collection.name))
+        remove_dir_all(&znap_collection_path)
+            .unwrap_or_else(|_| panic!("Could not delete .znap/{} folder", &collection.name))
     }
 
-    create_dir(&znap_collection_path).unwrap_or_else(|_| panic!("Could not create .znap/{} folder",
-        &collection.name));
+    create_dir(&znap_collection_path)
+        .unwrap_or_else(|_| panic!("Could not create .znap/{} folder", &collection.name));
 
     let znap_collection_src_path = znap_collection_path.join("src");
 
-    create_dir(&znap_collection_src_path).unwrap_or_else(|_| panic!("Could not create .znap/{}/src folder",
-        &collection.name));
+    create_dir(&znap_collection_src_path)
+        .unwrap_or_else(|_| panic!("Could not create .znap/{}/src folder", &collection.name));
 
     let znap_collection_src_bin_path = znap_collection_src_path.join("bin");
 
-    create_dir(&znap_collection_src_bin_path).unwrap_or_else(|_| panic!("Could not create .znap/{}/src/bin folder",
-        &collection.name));
+    create_dir(&znap_collection_src_bin_path)
+        .unwrap_or_else(|_| panic!("Could not create .znap/{}/src/bin folder", &collection.name));
 
     let collection_path = cwd.join(format!("collections/{}", &collection.name));
     let collection_src_path = collection_path.join("src");
@@ -245,7 +245,7 @@ pub fn generate_collection_executable_files(collection: &Collection) {
     );
 }
 
-pub fn build_for_release(name: &String) {
+pub fn build_for_release(name: &str) {
     std::process::Command::new("cargo")
         .arg("build")
         .arg("--manifest-path")

--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -46,11 +46,11 @@ pub fn get_config() -> Config {
     }
 }
 
-pub fn get_identity(identity: &String) -> String {
+pub fn get_identity(identity: &str) -> String {
     shellexpand::tilde(identity).into()
 }
 
-pub fn write_file(path: &Path, content: &String) {
+pub fn write_file(path: &Path, content: &str) {
     let mut file = File::create(path).expect("Should be able to open file");
     file.write_all(content.as_bytes())
         .expect("Should be able to write file");
@@ -139,7 +139,7 @@ pub fn wait_for_server(address: &str, port: &u16, protocol: &str) {
     }
 }
 
-pub fn deploy_to_shuttle(name: &String, project: &String) {
+pub fn deploy_to_shuttle(name: &str, project: &str) {
     std::process::Command::new("cargo")
         .arg("shuttle")
         .arg("deploy")
@@ -183,9 +183,7 @@ pub fn generate_collection_executable_files(collection: &Collection) {
 
     write_file(
         &znap_toml_path,
-        &String::from(
-            "[workspace]\nmembers = [\"collections/*\"]\nresolver = \"2\"\n\n[patch.crates-io]\ncurve25519-dalek = { git = \"https://github.com/dalek-cryptography/curve25519-dalek\", rev = \"8274d5cbb6fc3f38cdc742b4798173895cd2a290\" }",
-        ),
+        "[workspace]\nmembers = [\"collections/*\"]\nresolver = \"2\"\n\n[patch.crates-io]\ncurve25519-dalek = { git = \"https://github.com/dalek-cryptography/curve25519-dalek\", rev = \"8274d5cbb6fc3f38cdc742b4798173895cd2a290\" }",
     );
 
     let znap_collections_path = znap_path.join("collections");

--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -51,14 +51,14 @@ pub fn get_identity(identity: &String) -> String {
 }
 
 pub fn write_file(path: &Path, content: &String) {
-    let mut file = File::create(&path).expect("Should be able to open file");
+    let mut file = File::create(path).expect("Should be able to open file");
     file.write_all(content.as_bytes())
         .expect("Should be able to write file");
 }
 
 pub fn start_server_blocking(
-    name: &String,
-    identity: &String,
+    name: &str,
+    identity: &str,
     address: &Option<String>,
     port: &Option<u16>,
     protocol: &Option<String>,
@@ -100,7 +100,7 @@ pub fn start_server(
         .envs(env_vars)
         .arg("run")
         .arg("--manifest-path")
-        .arg(get_cwd().join(&format!(".znap/collections/{name}/Cargo.toml")))
+        .arg(get_cwd().join(format!(".znap/collections/{name}/Cargo.toml")))
         .arg("--bin")
         .arg("serve")
         .stdout(Stdio::inherit())
@@ -147,7 +147,7 @@ pub fn deploy_to_shuttle(name: &String, project: &String) {
         .arg("--name")
         .arg(project)
         .arg("--working-directory")
-        .arg(get_cwd().join(&format!(".znap/collections/{name}")))
+        .arg(get_cwd().join(format!(".znap/collections/{name}")))
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()
@@ -197,32 +197,24 @@ pub fn generate_collection_executable_files(collection: &Collection) {
     let znap_collection_path = znap_collections_path.join(&collection.name);
 
     if znap_collection_path.exists() {
-        remove_dir_all(&znap_collection_path).expect(&format!(
-            "Could not delete .znap/{} folder",
-            &collection.name
-        ))
+        remove_dir_all(&znap_collection_path).unwrap_or_else(|_| panic!("Could not delete .znap/{} folder",
+            &collection.name))
     }
 
-    create_dir(&znap_collection_path).expect(&format!(
-        "Could not create .znap/{} folder",
-        &collection.name
-    ));
+    create_dir(&znap_collection_path).unwrap_or_else(|_| panic!("Could not create .znap/{} folder",
+        &collection.name));
 
     let znap_collection_src_path = znap_collection_path.join("src");
 
-    create_dir(&znap_collection_src_path).expect(&format!(
-        "Could not create .znap/{}/src folder",
-        &collection.name
-    ));
+    create_dir(&znap_collection_src_path).unwrap_or_else(|_| panic!("Could not create .znap/{}/src folder",
+        &collection.name));
 
     let znap_collection_src_bin_path = znap_collection_src_path.join("bin");
 
-    create_dir(&znap_collection_src_bin_path).expect(&format!(
-        "Could not create .znap/{}/src/bin folder",
-        &collection.name
-    ));
+    create_dir(&znap_collection_src_bin_path).unwrap_or_else(|_| panic!("Could not create .znap/{}/src/bin folder",
+        &collection.name));
 
-    let collection_path = cwd.join(&format!("collections/{}", &collection.name));
+    let collection_path = cwd.join(format!("collections/{}", &collection.name));
     let collection_src_path = collection_path.join("src");
 
     copy_recursively(collection_src_path, znap_collection_src_path);
@@ -257,7 +249,7 @@ pub fn build_for_release(name: &String) {
     std::process::Command::new("cargo")
         .arg("build")
         .arg("--manifest-path")
-        .arg(get_cwd().join(&format!(".znap/collections/{name}/Cargo.toml")))
+        .arg(get_cwd().join(format!(".znap/collections/{name}/Cargo.toml")))
         .arg("--release")
         .arg("--bin")
         .arg("serve")

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -15,7 +15,7 @@ pub fn generate(action_struct: &ActionStruct) -> TokenStream {
         let mut segments: Vec<String> = vec!["/api".to_string(), action_name];
 
         for (param_name, _) in params_attrs {
-            segments.push(format!(":{}", param_name.to_string()));
+            segments.push(format!(":{}", param_name));
         }
 
         let action_path = segments.join("/");

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -24,7 +24,7 @@ fn generate_parameter(parameters: &[ActionLinkParameterStruct]) -> TokenStream {
     }
 }
 
-fn generate_links(links: &Vec<ActionLinkStruct>) -> TokenStream {
+fn generate_links(links: &[ActionLinkStruct]) -> TokenStream {
     let links: Vec<_> = links
         .iter()
         .map(|l| {
@@ -42,7 +42,7 @@ fn generate_links(links: &Vec<ActionLinkStruct>) -> TokenStream {
         })
         .collect();
 
-    if links.len() == 0 {
+    if links.is_empty() {
         quote! {
             None
         }

--- a/znap-syn/src/common.rs
+++ b/znap-syn/src/common.rs
@@ -67,10 +67,10 @@ pub fn extract_action_ident(f: &ItemFn) -> Option<&Ident> {
             if let PathArguments::AngleBracketed(inner_path) =
                 &type_path.path.segments.first()?.arguments
             {
-                if let GenericArgument::Type(inner_type) = inner_path.args.first()? {
-                    if let Type::Path(inner_type_path) = inner_type {
-                        return inner_type_path.path.segments.first().map(|seg| &seg.ident);
-                    }
+                if let GenericArgument::Type(Type::Path(inner_type_path)) =
+                    inner_path.args.first()?
+                {
+                    return inner_type_path.path.segments.first().map(|seg| &seg.ident);
                 }
             }
         }
@@ -78,8 +78,8 @@ pub fn extract_action_ident(f: &ItemFn) -> Option<&Ident> {
     None
 }
 
-pub fn action_name_without_suffix(action_name: &String) -> String {
-    let action_name_splitted: Vec<&str> = action_name.split('_').collect();
+pub fn action_name_without_suffix(action_name: &str) -> String {
+    let action_name_splitted: Vec<_> = action_name.split('_').collect();
     let (_, action_name_without_suffix) = action_name_splitted.split_last().unwrap();
 
     action_name_without_suffix.join("_")
@@ -91,10 +91,10 @@ pub fn extract_fn_result_type(f: &ItemFn) -> Option<&Ident> {
             if let PathArguments::AngleBracketed(inner_path) =
                 &type_path.path.segments.first().unwrap().arguments
             {
-                if let GenericArgument::Type(inner_type) = inner_path.args.first().unwrap() {
-                    if let Type::Path(inner_type_path) = inner_type {
-                        return Some(&inner_type_path.path.segments.first().unwrap().ident);
-                    }
+                if let GenericArgument::Type(Type::Path(inner_type_path)) =
+                    inner_path.args.first().unwrap()
+                {
+                    return Some(&inner_type_path.path.segments.first().unwrap().ident);
                 }
             }
         }
@@ -102,7 +102,7 @@ pub fn extract_fn_result_type(f: &ItemFn) -> Option<&Ident> {
     None
 }
 
-pub fn create_query(action: &String) -> Ident {
+pub fn create_query(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}Query",
@@ -112,7 +112,7 @@ pub fn create_query(action: &String) -> Ident {
     )
 }
 
-pub fn create_params(action: &String) -> Ident {
+pub fn create_params(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}Params",
@@ -122,7 +122,7 @@ pub fn create_params(action: &String) -> Ident {
     )
 }
 
-pub fn create_get_handler(action: &String) -> Ident {
+pub fn create_get_handler(action: &str) -> Ident {
     Ident::new(
         &format!(
             "handle_get_{}",
@@ -132,7 +132,7 @@ pub fn create_get_handler(action: &String) -> Ident {
     )
 }
 
-pub fn create_post_handler(action: &String) -> Ident {
+pub fn create_post_handler(action: &str) -> Ident {
     Ident::new(
         &format!(
             "handle_post_{}",
@@ -142,11 +142,11 @@ pub fn create_post_handler(action: &String) -> Ident {
     )
 }
 
-pub fn create_route_path(action: &String) -> String {
+pub fn create_route_path(action: &str) -> String {
     format!("/api/{}", &action.to_snek_case())
 }
 
-pub fn create_post_context(action: &String) -> Ident {
+pub fn create_post_context(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}PostContext",
@@ -156,7 +156,7 @@ pub fn create_post_context(action: &String) -> Ident {
     )
 }
 
-pub fn create_transaction(action: &String) -> Ident {
+pub fn create_transaction(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}_create_transaction",
@@ -166,7 +166,7 @@ pub fn create_transaction(action: &String) -> Ident {
     )
 }
 
-pub fn create_metadata(action: &String) -> Ident {
+pub fn create_metadata(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}_create_metadata",
@@ -176,7 +176,7 @@ pub fn create_metadata(action: &String) -> Ident {
     )
 }
 
-pub fn create_get_context(action: &String) -> Ident {
+pub fn create_get_context(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}GetContext",
@@ -186,7 +186,7 @@ pub fn create_get_context(action: &String) -> Ident {
     )
 }
 
-pub fn create_get_context_with_metadata(action: &String) -> Ident {
+pub fn create_get_context_with_metadata(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}GetContextWithMetadata",
@@ -196,7 +196,7 @@ pub fn create_get_context_with_metadata(action: &String) -> Ident {
     )
 }
 
-pub fn create_path(action: &String) -> Ident {
+pub fn create_path(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}_path",

--- a/znap-syn/src/common.rs
+++ b/znap-syn/src/common.rs
@@ -11,7 +11,7 @@ pub fn extract_attrs_by_name(
     action_struct.attrs.iter().find_map(|attr| {
         if let Ok(meta) = attr.meta.require_list() {
             if let Some(first_segment) = meta.path.segments.first() {
-                if first_segment.ident.to_string() == name {
+                if first_segment.ident == name {
                     let idents: &Vec<Ident> = &meta
                         .tokens
                         .clone()
@@ -25,7 +25,7 @@ pub fn extract_attrs_by_name(
                                 return Some(parsed_ident);
                             }
 
-                            return None;
+                            None
                         })
                         .collect();
                     let chunked_idents = idents.chunks(2);
@@ -43,7 +43,7 @@ pub fn extract_attrs_by_name(
             }
         }
 
-        return None;
+        None
     })
 }
 
@@ -51,13 +51,13 @@ pub fn has_action(action_struct: &ItemStruct) -> bool {
     action_struct.attrs.iter().any(|attr| {
         if let Ok(meta) = attr.meta.require_list() {
             if let Some(first_segment) = meta.path.segments.first() {
-                if first_segment.ident.to_string() == "action" {
+                if first_segment.ident == "action" {
                     return true;
                 }
             }
         }
 
-        return false;
+        false
     })
 }
 
@@ -79,7 +79,7 @@ pub fn extract_action_ident(f: &ItemFn) -> Option<&Ident> {
 }
 
 pub fn action_name_without_suffix(action_name: &String) -> String {
-    let action_name_splitted: Vec<&str> = action_name.split("_").collect();
+    let action_name_splitted: Vec<&str> = action_name.split('_').collect();
     let (_, action_name_without_suffix) = action_name_splitted.split_last().unwrap();
 
     action_name_without_suffix.join("_")

--- a/znap-syn/src/parser/action/mod.rs
+++ b/znap-syn/src/parser/action/mod.rs
@@ -5,9 +5,9 @@ mod params_attrs;
 mod query_attrs;
 
 pub fn parse(action_struct: &ItemStruct) -> ParseResult<ActionStruct> {
-    let action_attributes = attributes::parse(&action_struct)?;
-    let query_attrs = query_attrs::parse(&action_struct);
-    let params_attrs = params_attrs::parse(&action_struct);
+    let action_attributes = attributes::parse(action_struct)?;
+    let query_attrs = query_attrs::parse(action_struct);
+    let params_attrs = params_attrs::parse(action_struct);
 
     Ok(ActionStruct {
         name: action_struct.ident.clone(),

--- a/znap-syn/src/parser/collection/actions.rs
+++ b/znap-syn/src/parser/collection/actions.rs
@@ -16,7 +16,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<Ident>> {
         .iter()
         .filter_map(|item| match item {
             Item::Fn(item_fn) => {
-                if extract_fn_result_type(&item_fn).unwrap() == "ActionTransaction" {
+                if extract_fn_result_type(item_fn).unwrap() == "ActionTransaction" {
                     return Some(item_fn);
                 }
 
@@ -25,7 +25,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<Ident>> {
             _ => None,
         })
         .map(|method: &ItemFn| {
-            let action_ident = extract_action_ident(&method).unwrap();
+            let action_ident = extract_action_ident(method).unwrap();
 
             Ok(action_ident.clone())
         })

--- a/znap-syn/src/parser/collection/get_action_fns.rs
+++ b/znap-syn/src/parser/collection/get_action_fns.rs
@@ -19,7 +19,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<ActionFn>> {
         .iter()
         .filter_map(|item| match item {
             Item::Fn(item_fn) => {
-                if extract_fn_result_type(&item_fn).unwrap() == "ActionMetadata" {
+                if extract_fn_result_type(item_fn).unwrap() == "ActionMetadata" {
                     return Some(item_fn);
                 }
 
@@ -28,7 +28,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<ActionFn>> {
             _ => None,
         })
         .map(|method: &ItemFn| {
-            let action_ident = extract_action_ident(&method).unwrap();
+            let action_ident = extract_action_ident(method).unwrap();
 
             Ok(ActionFn {
                 raw_method: method.clone(),

--- a/znap-syn/src/parser/collection/mod.rs
+++ b/znap-syn/src/parser/collection/mod.rs
@@ -5,9 +5,9 @@ mod get_action_fns;
 mod post_action_fns;
 
 pub fn parse(collection_mod: &ItemMod) -> ParseResult<CollectionMod> {
-    let post_action_fns = post_action_fns::parse(&collection_mod)?;
-    let get_action_fns = get_action_fns::parse(&collection_mod)?;
-    let actions = actions::parse(&collection_mod)?;
+    let post_action_fns = post_action_fns::parse(collection_mod)?;
+    let get_action_fns = get_action_fns::parse(collection_mod)?;
+    let actions = actions::parse(collection_mod)?;
 
     Ok(CollectionMod {
         actions,

--- a/znap-syn/src/parser/collection/post_action_fns.rs
+++ b/znap-syn/src/parser/collection/post_action_fns.rs
@@ -19,7 +19,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<ActionFn>> {
         .iter()
         .filter_map(|item| match item {
             Item::Fn(item_fn) => {
-                if extract_fn_result_type(&item_fn).unwrap() == "ActionTransaction" {
+                if extract_fn_result_type(item_fn).unwrap() == "ActionTransaction" {
                     return Some(item_fn);
                 }
 
@@ -28,7 +28,7 @@ pub fn parse(collection_mod: &ItemMod) -> ParseResult<Vec<ActionFn>> {
             _ => None,
         })
         .map(|method: &ItemFn| {
-            let action_ident = extract_action_ident(&method).unwrap();
+            let action_ident = extract_action_ident(method).unwrap();
 
             Ok(ActionFn {
                 raw_method: method.clone(),

--- a/znap-syn/src/parser/error_code/mod.rs
+++ b/znap-syn/src/parser/error_code/mod.rs
@@ -3,7 +3,7 @@ use syn::{parse::Result as ParseResult, ItemEnum};
 mod error;
 
 pub fn parse(error_enum: &ItemEnum) -> ParseResult<ErrorEnum> {
-    let error_variants = error::parse(&error_enum)?;
+    let error_variants = error::parse(error_enum)?;
 
     Ok(ErrorEnum {
         name: error_enum.ident.clone(),

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -278,7 +278,7 @@ pub fn add_action_identity_proof(transaction: Transaction) -> Transaction {
     Transaction::new_unsigned(transaction_message_with_identity)
 }
 
-pub fn render_source<T>(source: &String, data: &T) -> String
+pub fn render_source<T>(source: &str, data: &T) -> String
 where
     T: Serialize,
 {
@@ -295,7 +295,7 @@ where
 }
 
 pub fn render_parameters<T>(
-    parameters: &Vec<LinkedActionParameter>,
+    parameters: &[LinkedActionParameter],
     data: &T,
 ) -> Vec<LinkedActionParameter>
 where
@@ -316,7 +316,7 @@ where
         .collect()
 }
 
-pub fn render_action_links<T>(links: &Option<ActionLinks>, data: &T) -> Option<ActionLinks>
+pub fn render_action_links<T>(links: Option<&ActionLinks>, data: &T) -> Option<ActionLinks>
 where
     T: Serialize,
 {
@@ -353,7 +353,7 @@ where
     let description = render_source(&metadata.description, &data);
     let label = render_source(&metadata.label, &data);
     let icon = render_source(&metadata.icon, &data);
-    let links = render_action_links(&metadata.links, &data);
+    let links = render_action_links(metadata.links.as_ref(), &data);
 
     ActionMetadata {
         title,

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Example
 //!
-//! ```rust
+//! ```ignore
 //! use solana_sdk::{message::Message, pubkey, pubkey::Pubkey, transaction::Transaction};
 //! use spl_associated_token_account::get_associated_token_address;
 //! use spl_token::{instruction::transfer, ID as TOKEN_PROGRAM_ID};

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -213,9 +213,7 @@ pub fn add_action_identity_proof(transaction: Transaction) -> Transaction {
     let identity_signature = identity_keypair.sign_message(&reference_pubkey.to_bytes());
     let identity_message = format!(
         "solana-action:{}:{}:{}",
-        identity_pubkey,
-        reference_pubkey,
-        identity_signature
+        identity_pubkey, reference_pubkey, identity_signature
     );
 
     let mut identity_added = false;

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -213,9 +213,9 @@ pub fn add_action_identity_proof(transaction: Transaction) -> Transaction {
     let identity_signature = identity_keypair.sign_message(&reference_pubkey.to_bytes());
     let identity_message = format!(
         "solana-action:{}:{}:{}",
-        identity_pubkey.to_string(),
-        reference_pubkey.to_string(),
-        identity_signature.to_string()
+        identity_pubkey,
+        reference_pubkey,
+        identity_signature
     );
 
     let mut identity_added = false;
@@ -285,9 +285,9 @@ where
     let mut handlebars = Handlebars::new();
 
     assert!(handlebars
-        .register_template_string(&"template", &source)
+        .register_template_string("template", source)
         .is_ok());
-    let output = handlebars.render(&"template", &data).unwrap();
+    let output = handlebars.render("template", &data).unwrap();
 
     handlebars.clear_templates();
 


### PR DESCRIPTION
I made some improvements apart from what clippy recommends, I was removing the `&String` by `&str` and `&Vec<_>` by `&[_]`, this because of these rules

- https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec
- https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_arg

I also fixed some things so that the tests can pass without problems, the code examples in the documentation comments are executed in the tests and we had one that has dependencies outside of our `Cargo.toml`, so I made Rust ignore that test to avoid problems.

this close #77 