### PR TITLE
Env context struct

### DIFF
--- a/znap-cli/src/commands/new.rs
+++ b/znap-cli/src/commands/new.rs
@@ -69,7 +69,7 @@ pub fn run(name: &str, dry_run: bool) {
             znap_toml_path.as_path(),
             &toml::to_string(&Config {
                 collections,
-                identity: "~/.config/solana/id.json".to_string(),
+                identity: None,
             })
             .unwrap(),
         );

--- a/znap-cli/src/commands/new.rs
+++ b/znap-cli/src/commands/new.rs
@@ -69,7 +69,7 @@ pub fn run(name: &str, dry_run: bool) {
             znap_toml_path.as_path(),
             &toml::to_string(&Config {
                 collections,
-                identity: None,
+                identity: Some("~/.config/solana/id.json".to_string()),
             })
             .unwrap(),
         );

--- a/znap-cli/src/commands/serve.rs
+++ b/znap-cli/src/commands/serve.rs
@@ -16,7 +16,7 @@ pub fn run(name: &str, address: Option<&str>, port: Option<&u16>, protocol: Opti
         // Run the server
         start_server_blocking(
             name,
-            &get_identity(&config.identity),
+            config.identity.as_deref().map(get_identity).as_deref(),
             address,
             port,
             protocol,

--- a/znap-cli/src/commands/test.rs
+++ b/znap-cli/src/commands/test.rs
@@ -19,7 +19,7 @@ pub fn run() {
         // Start server in background
         let server_process = start_server(
             &collection.name,
-            &get_identity(&config.identity),
+            config.identity.as_deref().map(get_identity).as_deref(),
             Some(&collection.address),
             Some(&collection.port),
             Some(&collection.protocol),

--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -25,7 +25,7 @@ pub struct Collection {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub collections: Option<Vec<Collection>>,
-    pub identity: String,
+    pub identity: Option<String>,
 }
 
 pub fn get_cwd() -> PathBuf {
@@ -58,7 +58,7 @@ pub fn write_file(path: &Path, content: &str) {
 
 pub fn start_server_blocking(
     name: &str,
-    identity: &str,
+    identity: Option<&str>,
     address: Option<&str>,
     port: Option<&u16>,
     protocol: Option<&str>,
@@ -75,14 +75,16 @@ pub fn start_server_blocking(
 
 pub fn start_server(
     name: &str,
-    identity: &str,
+    identity: Option<&str>,
     address: Option<&str>,
     port: Option<&u16>,
     protocol: Option<&str>,
 ) -> Child {
     let mut env_vars: HashMap<&str, String> = HashMap::new();
 
-    env_vars.insert("IDENTITY_KEYPAIR_PATH", identity.to_owned());
+    if let Some(i) = identity {
+        env_vars.insert("IDENTITY_KEYPAIR_PATH", i.to_owned());
+    }
 
     if let Some(address) = address {
         env_vars.insert("COLLECTION_ADDRESS", address.to_owned());

--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -82,7 +82,11 @@ pub fn start_server(
 ) -> Child {
     let mut env_vars: HashMap<&str, String> = HashMap::new();
 
-    if let Some(i) = identity {
+    if let Ok(path) = std::env::var("IDENTITY_KEYPAIR_PATH") {
+        env_vars.insert("IDENTITY_KEYPAIR_PATH", path);
+    } else if let Ok(v) = std::env::var("IDENTITY_KEYPAIR") {
+        env_vars.insert("IDENTITY_KEYPAIR", v);
+    } else if let Some(i) = identity {
         env_vars.insert("IDENTITY_KEYPAIR_PATH", i.to_owned());
     }
 

--- a/znap-syn/src/codegen/collection/handle_get.rs
+++ b/znap-syn/src/codegen/collection/handle_get.rs
@@ -26,11 +26,15 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context {
                             params: #params,
+                            #[serde::skip]
+                            env: znap::Env,
                         }
 
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context_with_metadata {
                             params: #params,
+                            #[serde::skip]
+                            env: znap::Env,
                             metadata: znap::ActionMetadata,
                         }
 
@@ -44,10 +48,12 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                             let raw_metadata = #action::to_metadata();
                             let context = #context {
                                 params,
+                                env: znap::Env::default(),
                             };
                             let rendered_metadata = znap::render_metadata(&raw_metadata, &context, false, None);
                             let context_with_metadata = #context_with_metadata {
                                 params: context.params,
+                                env: znap::Env::default(),
                                 metadata: rendered_metadata,
                             };
                             let metadata = #create_metadata_fn(context_with_metadata).await?;
@@ -61,6 +67,8 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context {
                             params: #params,
+                            #[serde::skip]
+                            env: znap::Env,
                         }
 
                         pub async fn #handler(
@@ -69,6 +77,7 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                             let raw_metadata = #action::to_metadata();
                             let context = #context {
                                 params,
+                                env: znap::Env::default(),
                             };
                             let rendered_metadata = znap::render_metadata(&raw_metadata, &context, false, None);
 

--- a/znap-syn/src/codegen/collection/handle_get.rs
+++ b/znap-syn/src/codegen/collection/handle_get.rs
@@ -26,15 +26,15 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context {
                             params: #params,
-                            #[serde::skip]
-                            env: znap::Env,
+                            #[serde(skip)]
+                            env: znap::env::Env,
                         }
 
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context_with_metadata {
                             params: #params,
-                            #[serde::skip]
-                            env: znap::Env,
+                            #[serde(skip)]
+                            env: znap::env::Env,
                             metadata: znap::ActionMetadata,
                         }
 
@@ -48,7 +48,7 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                             let raw_metadata = #action::to_metadata();
                             let context = #context {
                                 params,
-                                env: znap::Env::default(),
+                                env: znap::env::Env::default(),
                             };
                             let rendered_metadata = znap::render_metadata(&raw_metadata, &context, false, None);
                             let context_with_metadata = #context_with_metadata {
@@ -67,8 +67,8 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         #[derive(Debug, serde::Serialize, serde::Deserialize)]
                         pub struct #context {
                             params: #params,
-                            #[serde::skip]
-                            env: znap::Env,
+                            #[serde(skip)]
+                            env: znap::env::Env,
                         }
 
                         pub async fn #handler(
@@ -77,7 +77,7 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                             let raw_metadata = #action::to_metadata();
                             let context = #context {
                                 params,
-                                env: znap::Env::default(),
+                                env: znap::env::Env::default(),
                             };
                             let rendered_metadata = znap::render_metadata(&raw_metadata, &context, false, None);
 

--- a/znap-syn/src/codegen/collection/handle_post.rs
+++ b/znap-syn/src/codegen/collection/handle_post.rs
@@ -24,9 +24,9 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                 pub struct #context {
                     query: #query,
                     params: #params,
-                    payload: znap::CreateActionPayload
-                    #[serde::skip]
-                    env: znap::Env,
+                    payload: znap::CreateActionPayload,
+                    #[serde(skip)]
+                    env: znap::env::Env,
                 }
 
                 pub async fn #create_transaction_fn(ctx: &#context) -> znap::Result<znap::ActionTransaction> {
@@ -42,10 +42,10 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         payload,
                         query,
                         params,
-                        env: znap::Env::default(),
+                        env: znap::env::Env::default(),
                     };
                     let znap::ActionTransaction { transaction, message } = #create_transaction_fn(&context).await?;
-                    let transaction_with_identity = znap::add_action_identity_proof(transaction, &context.env);
+                    let transaction_with_identity = znap::add_action_identity_proof(transaction, &context.env.keypair);
                     let serialized_transaction = bincode::serialize(&transaction_with_identity).unwrap();
                     let encoded_transaction = BASE64_STANDARD.encode(serialized_transaction);
 

--- a/znap-syn/src/codegen/collection/handle_post.rs
+++ b/znap-syn/src/codegen/collection/handle_post.rs
@@ -25,9 +25,11 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                     query: #query,
                     params: #params,
                     payload: znap::CreateActionPayload
+                    #[serde::skip]
+                    env: znap::Env,
                 }
 
-                pub async fn #create_transaction_fn(ctx: #context) -> znap::Result<znap::ActionTransaction> {
+                pub async fn #create_transaction_fn(ctx: &#context) -> znap::Result<znap::ActionTransaction> {
                     #fn_block
                 }
 
@@ -40,9 +42,10 @@ pub fn generate(collection_mod: &CollectionMod) -> TokenStream {
                         payload,
                         query,
                         params,
+                        env: znap::Env::default(),
                     };
-                    let znap::ActionTransaction { transaction, message } = #create_transaction_fn(context).await?;
-                    let transaction_with_identity = znap::add_action_identity_proof(transaction);
+                    let znap::ActionTransaction { transaction, message } = #create_transaction_fn(&context).await?;
+                    let transaction_with_identity = znap::add_action_identity_proof(transaction, &context.env);
                     let serialized_transaction = bincode::serialize(&transaction_with_identity).unwrap();
                     let encoded_transaction = BASE64_STANDARD.encode(serialized_transaction);
 

--- a/znap/src/env.rs
+++ b/znap/src/env.rs
@@ -1,0 +1,21 @@
+use std::env::var;
+
+use solana_sdk::signature::Keypair;
+
+pub struct Env {
+    pub identity: Vec<u8>,
+    pub keypair: Keypair,
+}
+
+impl Default for Env {
+    fn default() -> Self {
+        let identity = var("IDENTITY_KEYPAIR_PATH")
+            .map(|path| std::fs::read(path).unwrap())
+            .or(var("IDENTITY_KEYPAIR").map(|v| v.as_bytes().to_vec()))
+            .expect("Cannot found `IDENTITY_KEYPAIR_PATH` or `IDENTITY_KEYPAIR` env var");
+
+        let keypair = Keypair::from_bytes(&identity).unwrap();
+
+        Self { identity, keypair }
+    }
+}

--- a/znap/src/env.rs
+++ b/znap/src/env.rs
@@ -2,6 +2,7 @@ use std::env::var;
 
 use solana_sdk::signature::Keypair;
 
+#[derive(Debug)]
 pub struct Env {
     pub identity: Vec<u8>,
     pub keypair: Keypair,

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -86,14 +86,25 @@ use solana_sdk::pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::{EncodableKey, Signer};
 use solana_sdk::transaction::Transaction;
-use std::env;
 pub extern crate base64;
 pub extern crate bincode;
 pub extern crate colored;
 pub extern crate tower_http;
 pub extern crate znap_macros;
 
-pub mod prelude;
+pub mod env;
+pub mod prelude {
+    pub use super::env::Env;
+    pub use super::{
+        Action, ActionLinks, ActionMetadata, ActionResponse, ActionTransaction, Error, ErrorCode,
+        LinkedAction, LinkedActionParameter, Result, ToMetadata,
+    };
+    pub use base64;
+    pub use bincode;
+    pub use colored;
+    pub use tower_http;
+    pub use znap_macros::{collection, Action, ErrorCode};
+}
 
 /// Trait used to transform a struct into an Action.
 pub trait Action {}
@@ -202,15 +213,13 @@ struct ErrorResponse {
     message: String,
 }
 
-pub fn add_action_identity_proof(transaction: Transaction) -> Transaction {
-    let identity_keypair =
-        Keypair::read_from_file(env::var("IDENTITY_KEYPAIR_PATH").unwrap()).unwrap();
-    let identity_pubkey = identity_keypair.pubkey();
+pub fn add_action_identity_proof(transaction: Transaction, env: &env::Env) -> Transaction {
+    let identity_pubkey = env.keypair.pubkey();
 
     let reference_keypair = Keypair::new();
     let reference_pubkey = reference_keypair.pubkey();
 
-    let identity_signature = identity_keypair.sign_message(&reference_pubkey.to_bytes());
+    let identity_signature = env.keypair.sign_message(&reference_pubkey.to_bytes());
     let identity_message = format!(
         "solana-action:{}:{}:{}",
         identity_pubkey, reference_pubkey, identity_signature

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -84,7 +84,7 @@ use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::message::Message;
 use solana_sdk::pubkey;
 use solana_sdk::signature::Keypair;
-use solana_sdk::signer::{EncodableKey, Signer};
+use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
 pub extern crate base64;
 pub extern crate bincode;

--- a/znap/src/lib.rs
+++ b/znap/src/lib.rs
@@ -213,13 +213,13 @@ struct ErrorResponse {
     message: String,
 }
 
-pub fn add_action_identity_proof(transaction: Transaction, env: &env::Env) -> Transaction {
-    let identity_pubkey = env.keypair.pubkey();
+pub fn add_action_identity_proof(transaction: Transaction, keypair: &Keypair) -> Transaction {
+    let identity_pubkey = keypair.pubkey();
 
     let reference_keypair = Keypair::new();
     let reference_pubkey = reference_keypair.pubkey();
 
-    let identity_signature = env.keypair.sign_message(&reference_pubkey.to_bytes());
+    let identity_signature = keypair.sign_message(&reference_pubkey.to_bytes());
     let identity_message = format!(
         "solana-action:{}:{}:{}",
         identity_pubkey, reference_pubkey, identity_signature

--- a/znap/src/prelude.rs
+++ b/znap/src/prelude.rs
@@ -1,9 +1,0 @@
-pub use crate::base64;
-pub use crate::bincode;
-pub use crate::colored;
-pub use crate::tower_http;
-pub use crate::znap_macros::{collection, Action, ErrorCode};
-pub use crate::{
-    Action, ActionLinks, ActionMetadata, ActionResponse, ActionTransaction, Error, ErrorCode,
-    LinkedAction, LinkedActionParameter, Result, ToMetadata,
-};


### PR DESCRIPTION
In this PR I am adding a structure to the context, for now it only contains information about the identity extracted from the corresponding environment variables `IDENTITY_KEYPAIR_PATH` or `IDENTITY_KEYPAIR`.

Additionally I removed the prelude file since it is not part of the convention to have such a file.

I also made the identity variable optional in the `Znap.toml` manifest, this might add the ability to detect if it is a path or a content.