### PR TITLE
Custom, Prefix and Shorthand Path

### DIFF
--- a/tests/send-donation/collections/my-actions/src/lib.rs
+++ b/tests/send-donation/collections/my-actions/src/lib.rs
@@ -35,6 +35,7 @@ pub mod my_actions {
     title = "Send a Donation to {{params.receiver_address}}",
     description = "Send a donation to {{params.receiver_address}} using the Solana blockchain via a Blink.",
     label = "Send",
+    prefix = "v1",
     link = {
         label = "Send 1 SOL",
         href = "/api/send_donation/{{params.receiver_address}}?amount=1",

--- a/tests/send-donation/collections/my-actions/src/lib.rs
+++ b/tests/send-donation/collections/my-actions/src/lib.rs
@@ -38,15 +38,15 @@ pub mod my_actions {
     prefix = "v1",
     link = {
         label = "Send 1 SOL",
-        href = "/api/send_donation/{{params.receiver_address}}?amount=1",
+        href = "/{{params.receiver_address}}?amount=1",
     },
     link = {
         label = "Send 5 SOL",
-        href = "/api/send_donation/{{params.receiver_address}}?amount=5",
+        href = "/{{params.receiver_address}}?amount=5",
     },
     link = {
         label = "Send SOL",
-        href = "/api/send_donation/{{params.receiver_address}}?amount={amount}",
+        href = "/{{params.receiver_address}}?amount={amount}",
         parameter = { label = "Amount in SOL", name = "amount" }
     },
 )]

--- a/tests/send-donation/collections/my-actions/src/lib.rs
+++ b/tests/send-donation/collections/my-actions/src/lib.rs
@@ -38,15 +38,15 @@ pub mod my_actions {
     prefix = "v1",
     link = {
         label = "Send 1 SOL",
-        href = "{{params.receiver_address}}?amount=1",
+        href = "?amount=1",
     },
     link = {
         label = "Send 5 SOL",
-        href = "{{params.receiver_address}}?amount=5",
+        href = "?amount=5",
     },
     link = {
         label = "Send SOL",
-        href = "{{params.receiver_address}}?amount={amount}",
+        href = "?amount={amount}",
         parameter = { label = "Amount in SOL", name = "amount" }
     },
 )]

--- a/tests/send-donation/collections/my-actions/src/lib.rs
+++ b/tests/send-donation/collections/my-actions/src/lib.rs
@@ -38,15 +38,15 @@ pub mod my_actions {
     prefix = "v1",
     link = {
         label = "Send 1 SOL",
-        href = "/{{params.receiver_address}}?amount=1",
+        href = "{{params.receiver_address}}?amount=1",
     },
     link = {
         label = "Send 5 SOL",
-        href = "/{{params.receiver_address}}?amount=5",
+        href = "{{params.receiver_address}}?amount=5",
     },
     link = {
         label = "Send SOL",
-        href = "/{{params.receiver_address}}?amount={amount}",
+        href = "{{params.receiver_address}}?amount={amount}",
         parameter = { label = "Amount in SOL", name = "amount" }
     },
 )]

--- a/tests/send-donation/tests/my-actions.ts
+++ b/tests/send-donation/tests/my-actions.ts
@@ -15,7 +15,7 @@ describe("My actions", () => {
   const aliceKeypair = Keypair.generate();
   const bobKeypair = Keypair.generate();
   const sendDonationClient = createActionClient(
-    `${baseUrl}/api/send_donation/${aliceKeypair.publicKey.toBase58()}`
+    `${baseUrl}/v1/send_donation/${aliceKeypair.publicKey.toBase58()}`
   );
   const actionMetadata: Metadata = {
     icon: "https://media.discordapp.net/attachments/1205590693041541181/1212566609202520065/icon.png?ex=667eb568&is=667d63e8&hm=0f247078545828c0a5cf8300a5601c56bbc9b59d3d87a0c74b082df0f3a6d6bd&=&format=webp&quality=lossless&width=660&height=660",
@@ -26,17 +26,17 @@ describe("My actions", () => {
       actions: [
         {
           label: "Send 1 SOL",
-          href: `/api/send_donation/${aliceKeypair.publicKey.toBase58()}?amount=1`,
+          href: `/v1/send_donation/${aliceKeypair.publicKey.toBase58()}?amount=1`,
           parameters: [],
         },
         {
           label: "Send 5 SOL",
-          href: `/api/send_donation/${aliceKeypair.publicKey.toBase58()}?amount=5`,
+          href: `/v1/send_donation/${aliceKeypair.publicKey.toBase58()}?amount=5`,
           parameters: [],
         },
         {
           label: "Send SOL",
-          href: `/api/send_donation/${aliceKeypair.publicKey.toBase58()}?amount={amount}`,
+          href: `/v1/send_donation/${aliceKeypair.publicKey.toBase58()}?amount={amount}`,
           parameters: [
             {
               label: "Amount in SOL",

--- a/znap-syn/src/codegen/action/mod.rs
+++ b/znap-syn/src/codegen/action/mod.rs
@@ -7,10 +7,10 @@ mod query;
 mod to_metadata;
 
 pub fn generate(action_struct: &ActionStruct) -> proc_macro2::TokenStream {
-    let to_metadata = to_metadata::generate(action_struct);
+    let (route, path) = path::generate(action_struct);
+    let to_metadata = to_metadata::generate(action_struct, &route);
     let query = query::generate(action_struct);
     let params = params::generate(action_struct);
-    let path = path::generate(action_struct);
     let name = name::generate(action_struct);
 
     quote! {

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -5,15 +5,35 @@ use crate::{
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn generate(action_struct: &ActionStruct) -> TokenStream {
+pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
     let path = create_path(&action_struct.name.to_string());
     let action_name = action_name_without_suffix(&action_struct.name.to_string());
-    let prefix = action_struct
+    let route = action_struct
         .attributes
         .as_ref()
-        .map(|attr| format!("/{}", attr.prefix))
+        .map(|attr| {
+            let path = if !attr.custom_path.contains("{{prefix}}") {
+                format!(
+                    "/{}/{}",
+                    attr.prefix,
+                    attr.custom_path.replace("{{action_name}}", &action_name)
+                )
+            } else {
+                format!(
+                    "/{}",
+                    attr.custom_path
+                        .replace("{{prefix}}", &attr.prefix)
+                        .replace("{{action_name}}", &action_name)
+                )
+            };
+            if !path.contains(&action_name) {
+                format!("{path}/{action_name}")
+            } else {
+                path
+            }
+        })
         .unwrap_or_default();
-    let mut segments = vec![prefix, action_name];
+    let mut segments = vec![route.clone()];
 
     if let Some(params_attrs) = &action_struct.params_attrs {
         segments.extend(
@@ -25,14 +45,20 @@ pub fn generate(action_struct: &ActionStruct) -> TokenStream {
 
         let action_path = segments.join("/");
 
-        quote! {
-            const #path: &str = #action_path;
-        }
+        (
+            route,
+            quote! {
+                const #path: &str = #action_path;
+            },
+        )
     } else {
         let action_path = segments.join("/");
 
-        quote! {
-            const #path: &str = #action_path;
-        }
+        (
+            route,
+            quote! {
+                const #path: &str = #action_path;
+            },
+        )
     }
 }

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -40,14 +40,14 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
             }
         })
         .unwrap_or_default();
-    let mut segments = vec![route.clone()];
 
     if let Some(params_attrs) = action_struct.params_attrs.as_ref() {
+        let mut segments = vec![route.clone()];
         segments.extend(
             params_attrs
                 .iter()
                 .filter_map(|(param_name, _)| {
-                    if route.contains(&param_name.to_string()) {
+                    if !route.contains(&param_name.to_string()) {
                         return Some(format!(":{param_name}"));
                     }
                     None
@@ -64,12 +64,10 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
             },
         )
     } else {
-        let action_path = segments.join("/");
-
         (
-            route,
+            route.clone(),
             quote! {
-                const #path: &str = #action_path;
+                const #path: &str = #route;
             },
         )
     }

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -15,8 +15,10 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
             let path = if !attr.custom_path.contains("{{prefix}}") {
                 format!(
                     "/{}/{}",
-                    attr.prefix,
-                    attr.custom_path.replace("{{action_name}}", &action_name)
+                    attr.prefix.trim_matches('/'),
+                    attr.custom_path
+                        .replace("{{action_name}}", &action_name)
+                        .trim_matches('/')
                 )
             } else {
                 format!(
@@ -24,6 +26,7 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
                     attr.custom_path
                         .replace("{{prefix}}", &attr.prefix)
                         .replace("{{action_name}}", &action_name)
+                        .trim_matches('/')
                 )
             };
             if !path.contains(&action_name) {

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -8,13 +8,20 @@ use quote::quote;
 pub fn generate(action_struct: &ActionStruct) -> TokenStream {
     let path = create_path(&action_struct.name.to_string());
     let action_name = action_name_without_suffix(&action_struct.name.to_string());
+    let prefix = action_struct
+        .attributes
+        .as_ref()
+        .map(|attr| format!("/{}", attr.prefix))
+        .unwrap_or_default();
+    let mut segments = vec![prefix, action_name];
 
     if let Some(params_attrs) = &action_struct.params_attrs {
-        let mut segments: Vec<String> = vec!["/api".to_string(), action_name];
-
-        for (param_name, _) in params_attrs {
-            segments.push(format!(":{}", param_name));
-        }
+        segments.extend(
+            params_attrs
+                .iter()
+                .map(|(param_name, _)| format!(":{param_name}"))
+                .collect::<Vec<_>>(),
+        );
 
         let action_path = segments.join("/");
 
@@ -22,7 +29,7 @@ pub fn generate(action_struct: &ActionStruct) -> TokenStream {
             const #path: &str = #action_path;
         }
     } else {
-        let action_path = format!("/api/{}", action_name);
+        let action_path = segments.join("/");
 
         quote! {
             const #path: &str = #action_path;

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -2,14 +2,12 @@ use crate::{
     common::{action_name_without_suffix, create_path},
     ActionStruct,
 };
-use heck::ToSnekCase;
 use proc_macro2::TokenStream;
 use quote::quote;
 
 pub fn generate(action_struct: &ActionStruct) -> TokenStream {
     let path = create_path(&action_struct.name.to_string());
-    let action_name =
-        action_name_without_suffix(&action_struct.name.to_string().to_snek_case()).to_snek_case();
+    let action_name = action_name_without_suffix(&action_struct.name.to_string());
 
     if let Some(params_attrs) = &action_struct.params_attrs {
         let mut segments: Vec<String> = vec!["/api".to_string(), action_name];

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -42,14 +42,19 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
         segments.extend(
             params_attrs
                 .iter()
-                .map(|(param_name, _)| format!(":{param_name}"))
+                .filter_map(|(param_name, _)| {
+                    if route.contains(&param_name.to_string()) {
+                        return Some(format!(":{param_name}"));
+                    }
+                    None
+                })
                 .collect::<Vec<_>>(),
         );
 
         let action_path = segments.join("/");
 
         (
-            route,
+            action_path.clone(),
             quote! {
                 const #path: &str = #action_path;
             },

--- a/znap-syn/src/codegen/action/path.rs
+++ b/znap-syn/src/codegen/action/path.rs
@@ -12,18 +12,18 @@ pub fn generate(action_struct: &ActionStruct) -> (String, TokenStream) {
         .attributes
         .as_ref()
         .map(|attr| {
-            let path = if !attr.custom_path.contains("{{prefix}}") {
+            let path = if !attr.path.contains("{{prefix}}") {
                 format!(
                     "/{}/{}",
                     attr.prefix.trim_matches('/'),
-                    attr.custom_path
+                    attr.path
                         .replace("{{action_name}}", &action_name)
                         .trim_matches('/')
                 )
             } else {
                 format!(
                     "/{}",
-                    attr.custom_path
+                    attr.path
                         .replace("{{prefix}}", &attr.prefix)
                         .replace("{{action_name}}", &action_name)
                         .trim_matches('/')

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -29,15 +29,11 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
         .iter()
         .map(|l| {
             let label = &l.label;
-            let href = if l.href.starts_with('/') {
-                l.href.clone()
-            } else {
-                format!("/{}", l.href)
-            };
+            let href = l.href.trim_matches('/');
             let href = if href.starts_with(route) {
-                href
+                href.to_owned()
             } else {
-                format!("{route}{href}")
+                format!("{route}/{href}")
             };
             let params = generate_parameter(&l.parameters);
 

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -30,7 +30,7 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
         .map(|l| {
             let label = &l.label;
             let href = l.href.trim_matches('/');
-            let href = if href.starts_with(route) {
+            let href = if href.starts_with(route) || href.starts_with("http") {
                 href.to_owned()
             } else {
                 format!("{route}/{href}")

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -42,7 +42,7 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
             quote! {
                 LinkedAction {
                     label: #label.to_string(),
-                    href: #href,
+                    href: #href.to_string(),
                     parameters: #params,
                 }
             }

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -24,18 +24,23 @@ fn generate_parameter(parameters: &[ActionLinkParameterStruct]) -> TokenStream {
     }
 }
 
-fn generate_links(links: &[ActionLinkStruct]) -> TokenStream {
+fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
     let links: Vec<_> = links
         .iter()
         .map(|l| {
             let label = &l.label;
-            let href = &l.href;
+            let href = if l.href.starts_with('/') {
+                l.href.clone()
+            } else {
+                format!("/{}", l.href)
+            };
+            let href = format!("{route}{href}");
             let params = generate_parameter(&l.parameters);
 
             quote! {
                 LinkedAction {
                     label: #label.to_string(),
-                    href: #href.to_string(),
+                    href: #href,
                     parameters: #params,
                 }
             }
@@ -57,7 +62,7 @@ fn generate_links(links: &[ActionLinkStruct]) -> TokenStream {
     }
 }
 
-pub fn generate(action_struct: &ActionStruct) -> TokenStream {
+pub fn generate(action_struct: &ActionStruct, route: &str) -> TokenStream {
     let name = &action_struct.name;
 
     if let Some(action_attributes) = &action_struct.attributes {
@@ -70,7 +75,7 @@ pub fn generate(action_struct: &ActionStruct) -> TokenStream {
             ..
         } = action_attributes;
 
-        let links = generate_links(links);
+        let links = generate_links(links, route);
 
         quote! {
             impl ToMetadata for #name {

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -67,6 +67,7 @@ pub fn generate(action_struct: &ActionStruct) -> TokenStream {
             label,
             icon,
             links,
+            ..
         } = action_attributes;
 
         let links = generate_links(links);

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -35,7 +35,17 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
             {
                 l.href.to_owned()
             } else {
-                format!("{route}/{}", l.href)
+                let route = route
+                    .split('/')
+                    .map(|r| {
+                        if r.starts_with(':') {
+                            return format!("{{{{params.{}}}}}", r.replace(':', ""));
+                        }
+                        r.to_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .join("/");
+                format!("{route}{}", l.href)
             };
             let params = generate_parameter(&l.parameters);
 

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -34,7 +34,11 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
             } else {
                 format!("/{}", l.href)
             };
-            let href = format!("{route}{href}");
+            let href = if href.starts_with(route) {
+                href
+            } else {
+                format!("{route}{href}")
+            };
             let params = generate_parameter(&l.parameters);
 
             quote! {

--- a/znap-syn/src/codegen/action/to_metadata.rs
+++ b/znap-syn/src/codegen/action/to_metadata.rs
@@ -29,11 +29,13 @@ fn generate_links(links: &[ActionLinkStruct], route: &str) -> TokenStream {
         .iter()
         .map(|l| {
             let label = &l.label;
-            let href = l.href.trim_matches('/');
-            let href = if href.starts_with(route) || href.starts_with("http") {
-                href.to_owned()
+            let href = if l.href.starts_with(route)
+                || l.href.starts_with("http")
+                || l.href.starts_with('/')
+            {
+                l.href.to_owned()
             } else {
-                format!("{route}/{href}")
+                format!("{route}/{}", l.href)
             };
             let params = generate_parameter(&l.parameters);
 

--- a/znap-syn/src/common.rs
+++ b/znap-syn/src/common.rs
@@ -79,10 +79,7 @@ pub fn extract_action_ident(f: &ItemFn) -> Option<&Ident> {
 }
 
 pub fn action_name_without_suffix(action_name: &str) -> String {
-    let action_name_splitted: Vec<_> = action_name.split('_').collect();
-    let (_, action_name_without_suffix) = action_name_splitted.split_last().unwrap();
-
-    action_name_without_suffix.join("_")
+    action_name.to_snek_case().replace("_action", "")
 }
 
 pub fn extract_fn_result_type(f: &ItemFn) -> Option<&Ident> {
@@ -106,7 +103,7 @@ pub fn create_query(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}Query",
-            action_name_without_suffix(&action.to_snek_case()).to_upper_camel_case()
+            action_name_without_suffix(action).to_upper_camel_case()
         ),
         Span::call_site(),
     )
@@ -116,7 +113,7 @@ pub fn create_params(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}Params",
-            action_name_without_suffix(&action.to_snek_case()).to_upper_camel_case()
+            action_name_without_suffix(action).to_upper_camel_case()
         ),
         Span::call_site(),
     )
@@ -124,20 +121,14 @@ pub fn create_params(action: &str) -> Ident {
 
 pub fn create_get_handler(action: &str) -> Ident {
     Ident::new(
-        &format!(
-            "handle_get_{}",
-            action_name_without_suffix(&action.to_snek_case())
-        ),
+        &format!("handle_get_{}", action_name_without_suffix(action)),
         Span::call_site(),
     )
 }
 
 pub fn create_post_handler(action: &str) -> Ident {
     Ident::new(
-        &format!(
-            "handle_post_{}",
-            action_name_without_suffix(&action.to_snek_case())
-        ),
+        &format!("handle_post_{}", action_name_without_suffix(action)),
         Span::call_site(),
     )
 }
@@ -150,7 +141,7 @@ pub fn create_post_context(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}PostContext",
-            action_name_without_suffix(&action.to_snek_case()).to_upper_camel_case()
+            action_name_without_suffix(action).to_upper_camel_case()
         ),
         Span::call_site(),
     )
@@ -158,20 +149,14 @@ pub fn create_post_context(action: &str) -> Ident {
 
 pub fn create_transaction(action: &str) -> Ident {
     Ident::new(
-        &format!(
-            "{}_create_transaction",
-            action_name_without_suffix(&action.to_snek_case())
-        ),
+        &format!("{}_create_transaction", action_name_without_suffix(action)),
         Span::call_site(),
     )
 }
 
 pub fn create_metadata(action: &str) -> Ident {
     Ident::new(
-        &format!(
-            "{}_create_metadata",
-            action_name_without_suffix(&action.to_snek_case())
-        ),
+        &format!("{}_create_metadata", action_name_without_suffix(action)),
         Span::call_site(),
     )
 }
@@ -180,7 +165,7 @@ pub fn create_get_context(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}GetContext",
-            action_name_without_suffix(&action.to_snek_case()).to_upper_camel_case()
+            action_name_without_suffix(action).to_upper_camel_case()
         ),
         Span::call_site(),
     )
@@ -190,7 +175,7 @@ pub fn create_get_context_with_metadata(action: &str) -> Ident {
     Ident::new(
         &format!(
             "{}GetContextWithMetadata",
-            action_name_without_suffix(&action.to_snek_case()).to_upper_camel_case()
+            action_name_without_suffix(action).to_upper_camel_case()
         ),
         Span::call_site(),
     )
@@ -198,11 +183,7 @@ pub fn create_get_context_with_metadata(action: &str) -> Ident {
 
 pub fn create_path(action: &str) -> Ident {
     Ident::new(
-        &format!(
-            "{}_path",
-            action_name_without_suffix(&action.to_snek_case())
-        )
-        .to_uppercase(),
+        &format!("{}_path", action_name_without_suffix(action)).to_uppercase(),
         Span::call_site(),
     )
 }

--- a/znap-syn/src/lib.rs
+++ b/znap-syn/src/lib.rs
@@ -97,6 +97,8 @@ pub struct ActionAttributesStruct {
     pub label: String,
     #[deluxe(default = "api".to_string())]
     pub prefix: String,
+    #[deluxe(default = "{{prefix}}/{{action_name}}".to_string())]
+    pub custom_path: String,
     #[deluxe(append, rename = link, default = Vec::new())]
     pub links: Vec<ActionLinkStruct>,
 }

--- a/znap-syn/src/lib.rs
+++ b/znap-syn/src/lib.rs
@@ -98,7 +98,7 @@ pub struct ActionAttributesStruct {
     #[deluxe(default = "api".to_string())]
     pub prefix: String,
     #[deluxe(default = "{{prefix}}/{{action_name}}".to_string())]
-    pub custom_path: String,
+    pub path: String,
     #[deluxe(append, rename = link, default = Vec::new())]
     pub links: Vec<ActionLinkStruct>,
 }

--- a/znap-syn/src/lib.rs
+++ b/znap-syn/src/lib.rs
@@ -95,10 +95,10 @@ pub struct ActionAttributesStruct {
     pub title: String,
     pub description: String,
     pub label: String,
-    #[deluxe(default = "api".to_string())]
-    pub prefix: String,
-    #[deluxe(default = "{{prefix}}/{{action_name}}".to_string())]
-    pub path: String,
+    // #[deluxe(default = Some("api".to_string()))]
+    pub prefix: Option<String>,
+    // #[deluxe(default = Some("{{prefix}}/{{action_name}}".to_string()))]
+    pub path: Option<String>,
     #[deluxe(append, rename = link, default = Vec::new())]
     pub links: Vec<ActionLinkStruct>,
 }

--- a/znap-syn/src/lib.rs
+++ b/znap-syn/src/lib.rs
@@ -95,6 +95,8 @@ pub struct ActionAttributesStruct {
     pub title: String,
     pub description: String,
     pub label: String,
+    #[deluxe(default = "api".to_string())]
+    pub prefix: String,
     #[deluxe(append, rename = link, default = Vec::new())]
     pub links: Vec<ActionLinkStruct>,
 }


### PR DESCRIPTION
this close #45
close #55
and close #61 

The following situations were added

- prefix system: The prefix follows the following rule `/{{prefix}}/{{action_name}}`
```rs
// Path generated
// /v1/send_donation
#[action(
    prefix = "v1",
)]
pub struct SendDonationAction;
```
- Custom path: the custom path obeys the format that is set, being {{prefix}} and {{action_name}} reserved fields that will be replaced in compilation when processing the macro, the default value is `/{{prefix}}/{{action_name}}`
```rs
// Case 1: no prefix
// Path generated: /api/my_super_app/send_donation
#[action( custom_path = "{{prefix}}/my_super_app/{{action_name}}" )]
pub struct SendDonationAction;

// Case 2: with prefix
// Path generated: /v1/my_super_app/send_donation
#[action(
    prefix = "v1",
    custom_path = "{{prefix}}/my_super_app/{{action_name}}",
)]
pub struct SendDonationAction;

// Case 3: no replacement
// Path generated: /v1/my_super_app
#[action(
    prefix = "v1",
    custom_path = "my_super_app",
)]
pub struct SendDonationAction;
```
- Shorthand syntax for Action Links: In this case it is simple when the beginning of the href does not match the generated path then add it.
```rs
// Case 1: example of normal use
// href generated: /v1/send_donation?amount=5 
#[action(
    prefix = "v1",
    link = {
        label = "Send 5 SOL",
        href = "?amount=5",
    },
)]
pub struct SendDonationAction;

// Case 2: misuse, but expected behavior
// href generated: /v1/send_donation/api/send_donation?amount=5 
#[action(
    prefix = "v1",
    link = {
        label = "Send 5 SOL",
        href = "/api/send_donation?amount=5",
    },
)]
pub struct SendDonationAction;
```