### PR TITLE
fix: false positive tests

### DIFF
--- a/znap-cli/src/utils/mod.rs
+++ b/znap-cli/src/utils/mod.rs
@@ -127,16 +127,15 @@ pub fn start_server(
 }
 
 pub fn run_test_suite() {
-    std::process::Command::new("npm")
+    let output = std::process::Command::new("npm")
         .arg("run")
         .arg("test")
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .map_err(anyhow::Error::from)
-        .expect("Should be able to run tests")
-        .wait_with_output()
+        .output()
         .expect("Should wait until the tests are over");
+
+    if !output.status.success() {
+        panic!("Test failed: {}", String::from_utf8_lossy(&output.stdout));
+    }
 }
 
 pub fn wait_for_server(address: &str, port: &u16, protocol: &str) {


### PR DESCRIPTION
close #89

The nodejs output for some reason and I have not been able to get the output at all.

> [!IMPORTANT]
> Example failed [here](https://github.com/heavy-duty/znap/actions/runs/10117566397/job/27982847385)